### PR TITLE
Revert get_contrib_path() change

### DIFF
--- a/bl602-flasher.py
+++ b/bl602-flasher.py
@@ -202,7 +202,7 @@ def prepend_fw_header(img, header_file):
 
 def get_contrib_path(name):
     sep = os.path.sep
-    return os.path.dirname(sys.executable) + sep + 'contrib' + sep + name
+    return os.path.dirname(os.path.realpath(__file__)) + sep + 'contrib' + sep + name
 
 def main():
     if len(sys.argv) < 3:


### PR DESCRIPTION
This PR fixes this error:
```
$ pio run -t upload
...
Traceback (most recent call last):
  File `"/home/<REDACTED>/.platformio/packages/tool-bl60x-flash/bl602-flasher.py",` line 233, in <module>
    main()
  File "/home/<REDACTED>/.platformio/packages/tool-bl60x-flash/bl602-flasher.py", line 218, in main
    load_image(ser, get_contrib_path('eflash_loader_40m.bin'))
  File "/home/<REDACTED>/.platformio/packages/tool-bl60x-flash/bl602-flasher.py", line 90, in load_image
    image = open(file, 'rb')
FileNotFoundError: [Errno 2] No such file or directory: '/home/<REDACTED>/.platformio/penv/bin/contrib/eflash_loader_40m.bin'

```